### PR TITLE
Fix Class Bridgepay\Bridge\Helper\Magento\Framework\App\State does no…

### DIFF
--- a/Helper/APIClient.php
+++ b/Helper/APIClient.php
@@ -242,7 +242,7 @@ class APIClient
     {
         $om = \Magento\Framework\App\ObjectManager::getInstance();
         /** @var \Magento\Framework\App\State $state */
-        $state = $om->get(Magento\Framework\App\State::class);
+        $state = $om->get(\Magento\Framework\App\State::class);
         return \Magento\Framework\App\State::MODE_DEVELOPER === $state->getMode();
     }
 }


### PR DESCRIPTION
**Fix: Class 'Bridgepay\Bridge\Helper\Magento\Framework\App\State' does not exist**

**Description:**
This patch addresses an issue where the class 'Bridgepay\Bridge\Helper\Magento\Framework\App\State' was not being recognized, leading to a fatal error. The issue was identified in the `Helper/APIClient.php` file.

**Changes:**
- In the `Helper/APIClient.php` file, corrected the class instantiation statement from:
  ```php
  $state = $om->get(Magento\Framework\App\State::class);
  ```
  to:
  ```php
  $state = $om->get(\Magento\Framework\App\State::class);
  ```

This fix ensures the proper recognition of the mentioned class, resolving the fatal error.

**Impact:**
This patch is crucial for preventing fatal errors related to the non-existence of the specified class. It ensures the smooth functioning of the codebase, particularly in scenarios where the mentioned class is utilized.
